### PR TITLE
Update files8x.c so large apps don't cause memory errors

### DIFF
--- a/src/files8x.c
+++ b/src/files8x.c
@@ -548,7 +548,9 @@ int ti8x_file_read_flash(const char *filename, Ti8xFlash *head)
 			content->pages = NULL;
 
 			// we should determine the number of pages, to do...
-			content->pages = g_malloc0((50+1) * sizeof(Ti8xFlashPage *));
+			//there could be more than 50 pages, but there should never be more than 256 pages
+			//if there was a bigger app then 50 pages, the overflow would break things
+			content->pages = g_malloc0((256+1) * sizeof(Ti8xFlashPage *));
 			if (content->pages == NULL)
 			{
 				return ERR_MALLOC;


### PR DESCRIPTION
There are more than 50 pages in some apps, which causes memory errors if you attempt to send one. I changed the amount of memory allocated so it can fit the number of flash pages the 84+CSE has, 256.
